### PR TITLE
feat: extend histogram buckets for slow request monitoring

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -70,6 +70,8 @@ func (p *Plugin) Init() error {
 			Namespace: namespace,
 			Name:      "request_duration_seconds",
 			Help:      "HTTP request duration.",
+			// Extended buckets to track slow requests (>10s)
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
 		},
 		[]string{"status"},
 	)


### PR DESCRIPTION
Add buckets for 20s, 30s, and 60s to the request_duration_seconds histogram to enable proper monitoring of slow HTTP requests.

Previously, all requests taking longer than 10 seconds would fall into the +Inf bucket, making it impossible to distinguish between requests taking 15s vs 45s.

# Reason for This PR

Relates to roadrunner-server/roadrunner#2274

As discussed in the issue, @rustatian suggested adding extended buckets without configuration.

## Description of Changes

Extended the default Prometheus histogram buckets for `rr_http_request_duration_seconds` from:
```
[.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
```
to:
```
[.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60]
```

This allows monitoring slow requests up to 60 seconds.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced HTTP request performance monitoring with improved metrics collection for slow requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->