### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -39,12 +39,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0/go.mod h1:BuhAPThV8PBHBvg8ZzZ/Ok3idOdhWIodywz2xEcRbJo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
-go.opentelemetry.io/contrib/propagators/jaeger v1.43.0 h1:peiLMz1+aqJE+3L4mOVtR9wlmv+yh/JVYXCBjqmzJJE=
-go.opentelemetry.io/contrib/propagators/jaeger v1.43.0/go.mod h1:Agvif+4A8p/3UtZzJ0MCcDEuQwgtrzM71DueU41DCs8=
 go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 h1:OyzvsAMc/zHt0DRPcfstn0wgfq8ApDkeY0ABMcueweM=
 go.opentelemetry.io/contrib/propagators/jaeger v1.44.0/go.mod h1:44kghcGX+BNxy9UTiWtd6VDt8Nd4EypGBkH2+v2Dqrc=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/plugin.go
+++ b/plugin.go
@@ -33,10 +33,10 @@ type Plugin struct {
 	stopCh      chan struct{}
 
 	queueSize       prometheus.Gauge
-	noFreeWorkers   *prometheus.CounterVec
+	noFreeWorkers   prometheus.Counter
 	requestCounter  *prometheus.CounterVec
 	requestDuration *prometheus.HistogramVec
-	uptime          *prometheus.CounterVec
+	uptime          prometheus.Counter
 }
 
 func (p *Plugin) Init() error {
@@ -48,18 +48,18 @@ func (p *Plugin) Init() error {
 		},
 	}
 
-	p.stopCh = make(chan struct{}, 1)
+	p.stopCh = make(chan struct{})
 	p.queueSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "requests_queue",
 		Help:      "Total number of queued requests.",
 	})
 
-	p.noFreeWorkers = prometheus.NewCounterVec(prometheus.CounterOpts{
+	p.noFreeWorkers = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "no_free_workers_total",
 		Help:      "Total number of NoFreeWorkers occurrences.",
-	}, nil)
+	})
 
 	p.requestCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
@@ -78,11 +78,11 @@ func (p *Plugin) Init() error {
 		[]string{statusLabel},
 	)
 
-	p.uptime = prometheus.NewCounterVec(prometheus.CounterOpts{
+	p.uptime = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "uptime_seconds",
 		Help:      "Uptime in seconds",
-	}, nil)
+	})
 
 	p.prop = propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}, jprop.Jaeger{})
 
@@ -98,7 +98,7 @@ func (p *Plugin) Serve() chan error {
 			case <-p.stopCh:
 				return
 			case <-ticker.C:
-				p.uptime.With(nil).Inc()
+				p.uptime.Inc()
 			}
 		}
 	}()
@@ -106,14 +106,14 @@ func (p *Plugin) Serve() chan error {
 }
 
 func (p *Plugin) Stop(context.Context) error {
-	p.stopCh <- struct{}{}
+	close(p.stopCh)
 	return nil
 }
 
 func (p *Plugin) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var otelVal string
 		var tp trace.TracerProvider
+		var otelVal string
 
 		if val, ok := r.Context().Value(rrcontext.OtelTracerNameKey).(string); ok {
 			otelVal = val
@@ -147,15 +147,16 @@ func (p *Plugin) Middleware(next http.Handler) http.Handler {
 		}
 
 		if w.Header().Get(noWorkers) == trueStr {
-			p.noFreeWorkers.With(nil).Inc()
+			p.noFreeWorkers.Inc()
 		}
 
+		statusCode := strconv.Itoa(rrWriter.code)
 		p.requestCounter.With(prometheus.Labels{
-			statusLabel: strconv.Itoa(rrWriter.code),
+			statusLabel: statusCode,
 		}).Inc()
 
 		p.requestDuration.With(prometheus.Labels{
-			statusLabel: strconv.Itoa(rrWriter.code),
+			statusLabel: statusCode,
 		}).Observe(time.Since(start).Seconds())
 
 		p.queueSize.Dec()

--- a/writer.go
+++ b/writer.go
@@ -9,6 +9,13 @@ type writer struct {
 	code int
 }
 
+// Unwrap implements the http.ResponseController unwrap interface so that
+// middleware chains that probe for http.Hijacker, http.Pusher, or HTTP/2
+// ResponseWriter extensions can reach the underlying ResponseWriter.
+func (w *writer) Unwrap() http.ResponseWriter {
+	return w.w
+}
+
 func (w *writer) Flush() {
 	if fl, ok := w.w.(http.Flusher); ok {
 		fl.Flush()
@@ -21,6 +28,11 @@ func (w *writer) WriteHeader(code int) {
 }
 
 func (w *writer) Write(b []byte) (int, error) {
+	// If WriteHeader was never called, Go's net/http defaults to 200.
+	// Mirror that here so the metrics label is accurate.
+	if w.code == -1 {
+		w.code = http.StatusOK
+	}
 	return w.w.Write(b)
 }
 


### PR DESCRIPTION
## Applied fixes

**R (Reliability)**
- `writer.go`: Add `Unwrap() http.ResponseWriter` so Hijacker, HTTP/2, and WebSocket promotion works through the metrics wrapper (was silently breaking those protocols)
- `writer.go`: Default `code` to 200 inside `Write()` — handlers that write a body without calling `WriteHeader` now record status 200 instead of -1

**S (Simplification)**
- `plugin.go`: `*CounterVec` with no labels replaced with `prometheus.Counter` for `noFreeWorkers` and `uptime` — cleaner API, no spurious `With(nil)` calls
- `plugin.go`: Size-1 buffered `stopCh` replaced with unbuffered channel + `close()` idiom — the correct Go pattern for a one-shot stop signal
- `plugin.go`: `strconv.Itoa(rrWriter.code)` captured once into `statusCode`; was evaluated twice (requestCounter + requestDuration)

**M (Modernization)**
- `plugin.go`: `var otelVal/tp` zero-decls reordered to group related declarations before the `if ok` block — minor scope clarity improvement

**Deps**
- `go get -u all && go mod tidy`

